### PR TITLE
add condition to assertions query

### DIFF
--- a/lib/db_query.js
+++ b/lib/db_query.js
@@ -25,6 +25,7 @@ async function getAssertionsByTestId({ testId }) {
   SELECT * 
   FROM assertions
   WHERE test_id = $1
+  AND active = true;
 `;
   const result = await dbQuery(query, testId);
   return result.rows;


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR adds a single condition to the assertions query to ensure that only "active" assertions are returned.

# Validation
Ran `npm run locally` and saw the following response: 
```
{  
results: [
    {
      assertionId: 199,
      assertionType: 'responseTime',
      targetValue: '200',
      actualValue: 1044,
      comparisonType: 'lessThan',
      property: null,
      success: false
    },
    {
      assertionId: 200,
      assertionType: 'statusCode',
      targetValue: '200',
      actualValue: 200,
      comparisonType: 'equalTo',
      property: null,
      success: true
    },
    {
      assertionId: 201,
      assertionType: 'body',
      targetValue: 'end2end-prototype',
      actualValue: 'end2end-prototype',
      comparisonType: 'equalTo',
      property: '$[0].title',
      success: true
    },
    {
      assertionId: 202,
      assertionType: 'header',
      targetValue: 'close',
      actualValue: 'close',
      comparisonType: 'equalTo',
      property: 'connection',
      success: true
    }
  ]
}
```
